### PR TITLE
2016-11-02 Fred Gleason <fredg@paravelsystems.com>

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -88,3 +88,5 @@
 	* Added an invocation to AR_GCC_TARGET() in 'configure.ac'.
 2016-11-02 Fred Gleason <fredg@paravelsystems.com>
 	* Corrected dependency in 'rivwebcapi.spec.in'.
+2016-11-02 Fred Gleason <fredg@paravelsystems.com>
+	* Added '-lcurl' to the 'libs:' field in 'rivendell.pc.in'.

--- a/rivendell.pc.in
+++ b/rivendell.pc.in
@@ -6,5 +6,5 @@ includedir=${prefix}/include/rivendell
 Name: Rivendell
 Description: Integration API for the Rivendell Radio Automation System
 Version: @VERSION@
-Libs: -L${libdir} -lrivwebcapi
+Libs: -L${libdir} -lrivwebcapi -lcurl
 Cflags: -I${includedir} -I/usr/include


### PR DESCRIPTION
Added a linker entry for the LibCurl dependency to the PkgConfig definition.

	* Added '-lcurl' to the 'libs:' field in 'rivendell.pc.in'.