### PR TITLE
2016-11-03 Fred Gleason <fredg@paravelsystems.com>

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -90,3 +90,5 @@
 	* Corrected dependency in 'rivwebcapi.spec.in'.
 2016-11-02 Fred Gleason <fredg@paravelsystems.com>
 	* Added '-lcurl' to the 'libs:' field in 'rivendell.pc.in'.
+2016-11-03 Fred Gleason <fredg@paravelsystems.com>
+	* Added 'extern "C"' defines to the headers in 'rivendell/'.

--- a/rivendell/rd_addcart.h
+++ b/rivendell/rd_addcart.h
@@ -23,6 +23,10 @@
 
 #include <rivendell/rd_cart.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 int RD_AddCart(struct rd_cart *cart[],
 			const char hostname[],
 			const char username[],
@@ -31,5 +35,9 @@ int RD_AddCart(struct rd_cart *cart[],
 			const char type[],
 			const unsigned cartnumber,
 			unsigned *numrecs);
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_ADDCART_H

--- a/rivendell/rd_addcut.h
+++ b/rivendell/rd_addcut.h
@@ -23,11 +23,19 @@
 
 #include <rivendell/rd_cut.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 int RD_AddCut(struct rd_cut *cut[],
 			const char hostname[],
 			const char username[],
 			const char passwd[],
 			const unsigned cartnumber,
 			unsigned *numrecs);
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_ADDCUT_H

--- a/rivendell/rd_assignschedcode.h
+++ b/rivendell/rd_assignschedcode.h
@@ -21,11 +21,18 @@
 #ifndef RD_ASSIGNSCHEDCODE_H
 #define RD_ASSIGNSCHEDCODE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
 
 int RD_AssignSchedCode( const char hostname[],
 			const char username[],
 			const char passwd[],
 			const unsigned cartnum,
 			const char code[]);
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_ASSIGNSCHEDCODE_H

--- a/rivendell/rd_audioinfo.h
+++ b/rivendell/rd_audioinfo.h
@@ -21,6 +21,10 @@
 #ifndef RD_AUDIOINFO_H
 #define RD_AUDIOINFO_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 struct rd_audioinfo {
   unsigned cart_number;
   unsigned cut_number;
@@ -38,5 +42,9 @@ int RD_AudioInfo(struct rd_audioinfo *audioinfo[],
 			const unsigned cartnumber,
                         const unsigned cutnumber,
 			unsigned *numrecs);
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_AUDIOINFO_H

--- a/rivendell/rd_audiostore.h
+++ b/rivendell/rd_audiostore.h
@@ -21,6 +21,10 @@
 #ifndef RD_AUDIOSTORE_H
 #define RD_AUDIOSTORE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 struct rd_audiostore {
   long unsigned freebytes;
   long unsigned totalbytes;
@@ -31,5 +35,9 @@ int RD_AudioStore(struct rd_audiostore *audiostore[],
 			const char username[],
 			const char passwd[],
 			unsigned *numrecs);
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_AUDIOSTORE_H

--- a/rivendell/rd_cart.h
+++ b/rivendell/rd_cart.h
@@ -14,6 +14,10 @@
 #ifndef RD_CART_H
 #define RD_CART_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 enum CART_TYPE {TYPE_ALL,TYPE_AUDIO,TYPE_MACRO};
 
 struct rd_cart {
@@ -45,5 +49,9 @@ struct rd_cart {
   char cart_notes[1024];
   char cart_metadata_datetime [26];
 };                      
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif   //RD_CART_H

--- a/rivendell/rd_common.h
+++ b/rivendell/rd_common.h
@@ -21,7 +21,14 @@
 #ifndef RD_COMMON_H
 #define RD_COMMON_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 extern unsigned RD_ReadBool(const char *val);
 
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_COMMON_H

--- a/rivendell/rd_copyaudio.h
+++ b/rivendell/rd_copyaudio.h
@@ -21,6 +21,10 @@
 #ifndef RD_COPYAUDIO_H
 #define RD_COPYAUDIO_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 int RD_CopyAudio( const char hostname[],
 			const char username[],
 			const char passwd[],
@@ -29,5 +33,8 @@ int RD_CopyAudio( const char hostname[],
 			const unsigned dest_cartnumber,
 			const unsigned dest_cutnumber);
 
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_COPYAUDIO_H

--- a/rivendell/rd_cut.h
+++ b/rivendell/rd_cut.h
@@ -21,6 +21,10 @@
 #ifndef RD_CUT_H
 #define RD_CUT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 struct rd_cut {
   char cut_name[11];
   unsigned cut_cart_number;
@@ -66,5 +70,9 @@ struct rd_cut {
   int cut_talk_start_point;
   int cut_talk_end_point;
 };
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_CUT_H

--- a/rivendell/rd_deleteaudio.h
+++ b/rivendell/rd_deleteaudio.h
@@ -21,11 +21,19 @@
 #ifndef RD_DELETEAUDIO_H
 #define RD_DELETEAUDIO_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 int RD_DeleteAudio( const char hostname[],
 			const char username[],
 			const char passwd[],
 			const unsigned cartnumber,
 			const unsigned cutnumber);
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RDDELETEAUDIO_H

--- a/rivendell/rd_editcart.h
+++ b/rivendell/rd_editcart.h
@@ -23,6 +23,10 @@
 
 #include <rivendell/rd_cart.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 struct edit_cart_values {
   char cart_grp_name[11];
   int use_cart_grp_name;
@@ -72,5 +76,10 @@ int RD_EditCart(struct rd_cart *cart[],
 
 
 void Build_Post_Cart_Fields(char *post, const struct edit_cart_values edit_cart_values);
+
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_EDITCART_H

--- a/rivendell/rd_editcut.h
+++ b/rivendell/rd_editcut.h
@@ -23,6 +23,10 @@
 
 #include <rivendell/rd_cut.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 struct edit_cut_values {
   int cut_evergreen;
   int use_cut_evergreen;
@@ -106,5 +110,9 @@ int RD_EditCut(struct rd_cut *cut[],
 
 void Build_Post_Cut_Fields(char *post, struct edit_cut_values edit_values);
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_EDITCUT_H

--- a/rivendell/rd_export.h
+++ b/rivendell/rd_export.h
@@ -21,6 +21,10 @@
 #ifndef RD_EXPORT_H
 #define RD_EXPORT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 int RD_ExportCart( const char hostname[],
 		 	const char         username[],
                         const char           passwd[],
@@ -37,5 +41,9 @@ int RD_ExportCart( const char hostname[],
                         const int     enable_metadata,
                         const char         filename[]);
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_EXPORT_H

--- a/rivendell/rd_exportpeaks.h
+++ b/rivendell/rd_exportpeaks.h
@@ -21,6 +21,10 @@
 #ifndef RD_EXPORTPEAKS_H
 #define RD_EXPORTPEAKS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 int RD_ExportPeaks( const char hostname[],
 		 	const char         username[],
                         const char           passwd[],
@@ -28,5 +32,9 @@ int RD_ExportPeaks( const char hostname[],
                         const unsigned         cutnum,
                         const char         filename[]);
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_EXPORTPEAKS_H

--- a/rivendell/rd_group.h
+++ b/rivendell/rd_group.h
@@ -14,6 +14,10 @@
 #ifndef RD_GROUP_H
 #define RD_GROUP_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 struct rd_group {
   char grp_name[11];
   char grp_desc[255];
@@ -30,5 +34,9 @@ struct rd_group {
   char grp_reserved[457];
 };
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif   // RD_GROUP_H

--- a/rivendell/rd_import.h
+++ b/rivendell/rd_import.h
@@ -21,6 +21,10 @@
 #ifndef RD_IMPORTCART_H
 #define RD_IMPORTCART_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 int RD_ImportCart( const char hostname[],
 			const char         username[],
 			const char           passwd[],
@@ -32,5 +36,9 @@ int RD_ImportCart( const char hostname[],
                         const int  use_metadata,
                         const char filename[]);
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_IMPORTCART_H

--- a/rivendell/rd_listcart.h
+++ b/rivendell/rd_listcart.h
@@ -23,6 +23,10 @@
 
 #include <rivendell/rd_cart.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 int RD_ListCart(struct rd_cart *carts[],
 		  	const char hostname[],
 			const char username[],
@@ -30,5 +34,9 @@ int RD_ListCart(struct rd_cart *carts[],
 			const unsigned cartnumber,
 			unsigned *numrecs);
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_LISTCART_H

--- a/rivendell/rd_listcarts.h
+++ b/rivendell/rd_listcarts.h
@@ -23,6 +23,10 @@
 
 #include <rivendell/rd_cart.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 int RD_ListCarts(struct rd_cart *carts[],
 		  	const char hostname[],
 			const char username[],
@@ -31,5 +35,10 @@ int RD_ListCarts(struct rd_cart *carts[],
                         const char filter[],
                         const char type[],
 			unsigned *numrecs);
+
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_LISTCARTS_H

--- a/rivendell/rd_listcartschedcodes.h
+++ b/rivendell/rd_listcartschedcodes.h
@@ -23,11 +23,20 @@
 
 #include <rivendell/rd_schedcodes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 int RD_ListCartSchedCodes(struct rd_schedcodes *schedcodes[],
 		  	const char hostname[],
 			const char username[],
 			const char passwd[],
 			const unsigned cartnum,
 			unsigned *numrecs);
+
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_LISTCARTSCHEDCODES_H

--- a/rivendell/rd_listcut.h
+++ b/rivendell/rd_listcut.h
@@ -23,6 +23,10 @@
 
 #include <rivendell/rd_cut.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 int RD_ListCut(struct rd_cut *cuts[],
 		  	const char hostname[],
 			const char username[],
@@ -31,5 +35,9 @@ int RD_ListCut(struct rd_cut *cuts[],
                         const unsigned cutnumber,
 			unsigned *numrecs);
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_LISTCUT_H

--- a/rivendell/rd_listcuts.h
+++ b/rivendell/rd_listcuts.h
@@ -23,11 +23,20 @@
 
 #include <rivendell/rd_cut.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 int RD_ListCuts(struct rd_cut *cuts[],
 		  	const char hostname[],
 			const char username[],
 			const char passwd[],
 			const unsigned cartnumber,
 			unsigned *numrecs);
+
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_LISTCUTS_H

--- a/rivendell/rd_listgroup.h
+++ b/rivendell/rd_listgroup.h
@@ -23,6 +23,10 @@
 
 #include <rivendell/rd_group.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 int RD_ListGroup(struct rd_group *grp[],
 		  	const char hostname[],
 			const char username[],
@@ -30,5 +34,9 @@ int RD_ListGroup(struct rd_group *grp[],
 			const char group[],
 			unsigned *numrecs);
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_LISTGROUP_H

--- a/rivendell/rd_listgroups.h
+++ b/rivendell/rd_listgroups.h
@@ -23,11 +23,18 @@
 
 #include <rivendell/rd_group.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int RD_ListGroups(struct rd_group *grps[],
 		  	const char hostname[],
 			const char username[],
 			const char passwd[],
 			unsigned *numrecs);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // RD_LISTGROUPS_H

--- a/rivendell/rd_listlog.h
+++ b/rivendell/rd_listlog.h
@@ -21,6 +21,10 @@
 #ifndef RD_LISTLOG_H
 #define RD_LISTLOG_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 struct rd_logline {
   int  logline_line;
   int  logline_id;
@@ -84,5 +88,9 @@ int RD_ListLog(struct rd_logline *logline[],
 			const char logname[],
 			unsigned *numrecs);
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_LISTLOG_H

--- a/rivendell/rd_listlogs.h
+++ b/rivendell/rd_listlogs.h
@@ -21,6 +21,10 @@
 #ifndef RD_LISTLOGS_H
 #define RD_LISTLOGS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 struct rd_log {
   char  log_name[11];
   char  log_service[11];
@@ -48,5 +52,9 @@ int RD_ListLogs(struct rd_log *logs[],
                         const int  trackable,
 			unsigned *numrecs);
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_LISTLOGS_H

--- a/rivendell/rd_listschedcodes.h
+++ b/rivendell/rd_listschedcodes.h
@@ -23,11 +23,19 @@
 
 #include <rivendell/rd_schedcodes.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 int RD_ListSchedCodes(struct rd_schedcodes *schedcodes[],
 		  	const char hostname[],
 			const char username[],
 			const char passwd[],
 			unsigned *numrecs);
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_LISTSCHEDCODES_H

--- a/rivendell/rd_listservices.h
+++ b/rivendell/rd_listservices.h
@@ -21,6 +21,10 @@
 #ifndef RD_LISTSERVICES_H
 #define RD_LISTSERVICES_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 struct rd_service {
   char service_name [11];
   char service_description[256];
@@ -33,5 +37,9 @@ int RD_ListServices(struct rd_service *services[],
 			const int  trackable,
 			unsigned *numrecs);
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_LISTSERVICES_H

--- a/rivendell/rd_removecart.h
+++ b/rivendell/rd_removecart.h
@@ -21,10 +21,18 @@
 #ifndef RD_REMOVECART_H
 #define RD_REMOVECART_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 int RD_RemoveCart( const char hostname[],
 			const char username[],
 			const char passwd[],
 			const unsigned cartnumber);
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_REMOVECART_H

--- a/rivendell/rd_removecut.h
+++ b/rivendell/rd_removecut.h
@@ -21,11 +21,19 @@
 #ifndef RD_REMOVECUT_H
 #define RD_REMOVECUT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 int RD_RemoveCut( const char hostname[],
 			const char username[],
 			const char passwd[],
 			const unsigned cartnumber,
 			const unsigned cutnumber);
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_REMOVECUT_H

--- a/rivendell/rd_schedcodes.h
+++ b/rivendell/rd_schedcodes.h
@@ -16,10 +16,18 @@
 #ifndef RD_SCHEDCODES_H
 #define RD_SCHEDCODES_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 struct rd_schedcodes {
   char code[11];
   char description[255];
 };
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  //RD_SCHEDCODES_H

--- a/rivendell/rd_trimaudio.h
+++ b/rivendell/rd_trimaudio.h
@@ -21,6 +21,10 @@
 #ifndef RD_TRIMAUDIO_H
 #define RD_TRIMAUDIO_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
+
 struct rd_trimaudio {
   unsigned cart_number;
   unsigned cut_number;
@@ -38,5 +42,9 @@ int RD_TrimAudio(struct rd_trimaudio *trimaudio[],
 			const int trimlevel,
 			unsigned *numrecs);
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_TRIMAUDIO_H

--- a/rivendell/rd_unassignschedcode.h
+++ b/rivendell/rd_unassignschedcode.h
@@ -21,6 +21,9 @@
 #ifndef RD_UNASSIGNSCHEDCODE_H
 #define RD_UNASSIGNSCHEDCODE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplug
 
 int RD_UnassignSchedCode( const char hostname[],
 			const char username[],
@@ -28,5 +31,9 @@ int RD_UnassignSchedCode( const char hostname[],
 			const unsigned cartnum,
 			const char code[]);
 
+
+#ifdef __cplusplus
+}
+#endif  // _cplusplus
 
 #endif  // RD_UNASSIGNSCHEDCODE_H


### PR DESCRIPTION
This adds 'extern "C"' wrappers around all of the API headers, thus making it possible to link to the library from C++.

	* Added 'extern "C"' defines to the headers in 'rivendell/'.