### PR TITLE
2017-01-11 Fred Gleason <fredg@paravelsystems.com>

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -99,3 +99,7 @@
           if it doesn't exist. Includes create flag and group name. Updated Docbook entry.
           Also updated importcart_test to include this functionality. Updated
 	  Originator.
+2017-01-11 Fred Gleason <fredg@paravelsystems.com>
+	* Fixed a fencepost error in 'rivendell/rd_listlog.c' that caused
+	the last character of the log name to be truncated when calling
+	rd_listlog().

--- a/rivendell/rd_listlog.c
+++ b/rivendell/rd_listlog.c
@@ -386,7 +386,7 @@ int RD_ListLog(struct rd_logline *logline[],
     return 404;        /* Log Name Incorrect */
   }
   memset(real_logname,'\0',sizeof(real_logname));
-  for (i = 0; i<strlen(logname)-1;i++)  {
+  for (i = 0; i<strlen(logname);i++)  {
     if (logname[i]>32) {
       strncpy(real_index,&logname[i],1);
       real_index++;


### PR DESCRIPTION
	* Fixed a fencepost error in 'rivendell/rd_listlog.c' that caused
	the last character of the log name to be truncated when calling
	rd_listlog().