### PR TITLE
Listlog type fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -99,3 +99,7 @@
           if it doesn't exist. Includes create flag and group name. Updated Docbook entry.
           Also updated importcart_test to include this functionality. Updated
 	  Originator.
+2017-01-11 Fred Gleason <fredg@paravelsystems.com>
+	* Fixed a fencepost error in 'rivendell/rd_listlog.c' that caused
+	the last character of the log name to be truncated when calling
+	rd_listlog().

--- a/ChangeLog
+++ b/ChangeLog
@@ -103,3 +103,6 @@
 	* Fixed a fencepost error in 'rivendell/rd_listlog.c' that caused
 	the last character of the log name to be truncated when calling
 	rd_listlog().
+2017-01-11 Fred Gleason <fredg@paravelsystems.com>
+	* Fixed a bug in 'rivendell/rd_listlog.c' that used the incorrect
+	keyword for detecting audio carts when calling rd_listlog().

--- a/rivendell/rd_listlog.c
+++ b/rivendell/rd_listlog.c
@@ -386,7 +386,7 @@ int RD_ListLog(struct rd_logline *logline[],
     return 404;        /* Log Name Incorrect */
   }
   memset(real_logname,'\0',sizeof(real_logname));
-  for (i = 0; i<strlen(logname)-1;i++)  {
+  for (i = 0; i<strlen(logname);i++)  {
     if (logname[i]>32) {
       strncpy(real_index,&logname[i],1);
       real_index++;

--- a/rivendell/rd_listlog.c
+++ b/rivendell/rd_listlog.c
@@ -77,7 +77,7 @@ static void XMLCALL __ListLogElementEnd(void *data, const char *el)
     sscanf(xml_data->strbuf,"%d",&logline->logline_id);
   }
   if(strcasecmp(el,"type")==0) {
-    if(strcasecmp(xml_data->strbuf,"Cart")==0) {
+    if(strcasecmp(xml_data->strbuf,"Audio")==0) {
       logline->logline_type=0;
     }
     if(strcasecmp(xml_data->strbuf,"Marker")==0) {


### PR DESCRIPTION
	* Fixed a bug in 'rivendell/rd_listlog.c' that used the incorrect
	keyword for detecting audio carts when calling rd_listlog().
