### PR TITLE
2017-01-18 Fred Gleason <fredg@paravelsystems.com>

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -121,3 +121,11 @@
 	* Added a test in 'configure.ac' for MingW32.
 	* Added a test in 'rivendell/rd_common.h' to avoid breaking the
 	build under MingW32.
+2017-01-18 Fred Gleason <fredg@paravelsystems.com>
+	* Added a 'logname' call parameter to rd_listlogs().
+	* Added a 'log_purge_date' field to the 'rd_log' struct in
+	'rivendell\rd_listlogs.h'.
+	* Fixed bugs in 'rivendell/rd_listlogs.c' where uninitialized variables
+	could introduce garbage into the Web API call.
+	* Applied URL encoding to the string parameters for the ListLogs
+	Web API call.

--- a/docbook/listlogs.xml
+++ b/docbook/listlogs.xml
@@ -36,6 +36,7 @@
       <paramdef>const char <parameter>hostname[]</parameter></paramdef>
       <paramdef>const char <parameter>username[]</parameter></paramdef>
       <paramdef>const char <parameter>passwd[]</parameter></paramdef>
+      <paramdef>const char <parameter>logname[]</parameter></paramdef>
       <paramdef>const char <parameter>servicename[]</parameter></paramdef>
       <paramdef>const int  <parameter>trackable</parameter></paramdef>
       <paramdef>unsigned * <parameter>numrecs</parameter></paramdef>
@@ -148,6 +149,20 @@
         </row>
         <row>
           <entry>
+            logname
+          </entry>
+          <entry>
+          character array
+          </entry>
+          <entry>
+            Log Name
+          </entry>
+          <entry>
+            Optional
+          </entry>
+        </row>
+        <row>
+          <entry>
             trackable
           </entry>
           <entry>
@@ -189,6 +204,7 @@
   		char  log_description[65];
   		char  log_origin_username[256];
   		char  log_origin_datetime[26];
+		char  log_purge_date[26];
   		char  log_link_datetime[26];
   		char  log_modified_datetime[26];
   		int   log_autorefresh;

--- a/rivendell/rd_listlogs.h
+++ b/rivendell/rd_listlogs.h
@@ -30,6 +30,7 @@ struct rd_log {
   char  log_description[65];
   char  log_origin_username[256];
   char  log_origin_datetime[26];
+  char  log_purge_date[26];
   char  log_link_datetime[26];
   char  log_modified_datetime[26];
   int   log_autorefresh;
@@ -48,6 +49,7 @@ int RD_ListLogs(struct rd_log *logs[],
 			const char username[],
 			const char passwd[],
 			const char servicename[],
+			const char logname[],
                         const int  trackable,
 			unsigned *numrecs);
 

--- a/tests/listlogs_test.c
+++ b/tests/listlogs_test.c
@@ -30,7 +30,8 @@ int main(int argc,char *argv[])
   struct rd_log *logs=0;
   char buf[BUFSIZ];
   char *p;
-  char svcname[11];
+  char svcname[11]={0};
+  char logname[65]={0};
   long int trackable=0;
   unsigned numrecs;
   char *host;
@@ -65,6 +66,12 @@ int main(int argc,char *argv[])
     strncpy(svcname,buf,10);
   } 
   fflush(stdin);
+  printf("Please enter the Log Name (default is All) ==> ");
+  if(fgets(buf,sizeof(buf),stdin) != NULL)
+  {
+    strncpy(logname,buf,64);
+  } 
+  fflush(stdin);
   printf("Please enter 1 if you want trackable logs ==>");
   if (fgets(buf,sizeof(buf),stdin) != NULL)
   {
@@ -87,6 +94,7 @@ int main(int argc,char *argv[])
 		user,
 		passwd,
 		&svcname[0],
+		&logname[0],
 		(int)trackable,
 		&numrecs); 
 
@@ -105,6 +113,7 @@ int main(int argc,char *argv[])
     printf("            Log Description: %s\n",logs[i].log_description);
     printf("       Log Origin User Name: %s\n",logs[i].log_origin_username);
     printf("        Log Origin DateTime: %s\n",logs[i].log_origin_datetime);
+    printf("             Log Purge Date: %s\n",logs[i].log_purge_date);
     printf("          Log Link DateTime: %s\n",logs[i].log_link_datetime);
     printf("      Log Modified DateTime: %s\n",logs[i].log_modified_datetime);
     printf("            Log AutoRefresh: %d\n",logs[i].log_autorefresh);


### PR DESCRIPTION
This adds support for two new attributes in the ListLogs web method:
   1) The 'LOG_NAME' call parameter
   2) The '&lt;purgeDate&gt;' return field.

A couple of bugfixes as well (see below).
	* Added a 'logname' call parameter to rd_listlogs().
	* Added a 'log_purge_date' field to the 'rd_log' struct in
	'rivendell\rd_listlogs.h'.
	* Fixed bugs in 'rivendell/rd_listlogs.c' where uninitialized variables
	could introduce garbage into the Web API call.
	* Applied URL encoding to the string parameters for the ListLogs
	Web API call.