### PR TITLE
Tm converter fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -179,3 +179,6 @@
 2017-02-03 Todd Baker <bakert@rfa.org>
 	* Updated comments in rivendell/rd_common.c, rivendell/rd_addcart.c 
 	and rivendell/rd_addcart.h.
+2017-02-03 Fred Gleason <fredg@paravelsystems.com>
+	* Fixed a bug in 'RD_Cnv_tm_to_DTString()' in 'rivendell/rd_common.c'
+	that caused a segfault when passed a null 'struct tm' value.

--- a/rivendell/rd_common.c
+++ b/rivendell/rd_common.c
@@ -159,7 +159,7 @@ size_t RD_Cnv_tm_to_DTString(struct tm *tmptr,char * dest)
      
     if (!validate_tm(tmptr))
     {
-        strcpy(dest,'\0');
+        dest[0]=0;
         return 0;
     }
     offsetfromutc = get_local_offset();


### PR DESCRIPTION
2017-02-03 Fred Gleason <fredg@paravelsystems.com>
	* Fixed a bug in 'RD_Cnv_tm_to_DTString()' in 'rivendell/rd_common.c'
	that caused a segfault when passed a null 'struct tm' value.