### PR TITLE
Save log fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -189,3 +189,7 @@
 	'save_logline_values' struct in 'rivendell/rd_savelog.h'.
 	* Fixed typos in 'rivendell/rd_savelog.c' that broke the
 	RD_SaveLog() call.
+	* Altered the 'logline_link_starttime' and 'logline_ext_starttime'
+	fields of 'struct save_logline_values' to be 'struct tm' instead
+	of 'char []'.
+	* Added an rd_savelog(7) man page.

--- a/ChangeLog
+++ b/ChangeLog
@@ -182,3 +182,10 @@
 2017-02-03 Fred Gleason <fredg@paravelsystems.com>
 	* Fixed a bug in 'RD_Cnv_tm_to_DTString()' in 'rivendell/rd_common.c'
 	that caused a segfault when passed a null 'struct tm' value.
+2017-02-08 Fred Gleason <fredg@paravelsystems.com>
+	* Added the 'logline_gracetime' field to the
+	'save_logline_values' struct in 'rivendell/rd_savelog.h'.
+	* Added the 'logline_link_length' field to the
+	'save_logline_values' struct in 'rivendell/rd_savelog.h'.
+	* Fixed typos in 'rivendell/rd_savelog.c' that broke the
+	RD_SaveLog() call.

--- a/docbook/Makefile.am
+++ b/docbook/Makefile.am
@@ -115,6 +115,9 @@ all-local:	rd_addcart.html\
                 rd_removecut.html\
                 rd_removecut.pdf\
                 rd_removecut.xml\
+                rd_savelog.html\
+                rd_savelog.pdf\
+                rd_savelog.xml\
                 rd_trimaudio.html\
                 rd_trimaudio.pdf\
                 rd_trimaudio.xml\
@@ -149,6 +152,7 @@ man_MANS = rd_addcart.7\
            rd_listservices.7\
            rd_removecart.7\
            rd_removecut.7\
+           rd_savelog.7\
            rd_trimaudio.7\
            rd_unassignschedcode.7
 
@@ -263,6 +267,10 @@ EXTRA_DIST = rd_addcart.7\
              rd_removecut.html\
              rd_removecut.pdf\
              rd_removecut.xml\
+             rd_savelog.7\
+             rd_savelog.html\
+             rd_savelog.pdf\
+             rd_savelog.xml\
              rd_trimaudio.7\
              rd_trimaudio.html\
              rd_trimaudio.pdf\

--- a/docbook/rd_savelog.xml
+++ b/docbook/rd_savelog.xml
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<refentry id="stdin" xmlns="http://docbook.org/ns/docbook" version="5.0">
+  <!--
+                    Header
+  -->
+  <refmeta>
+    <refentrytitle>RD_SaveLog</refentrytitle>
+    <manvolnum>7</manvolnum>
+    <refmiscinfo class='source'>February 2017</refmiscinfo>
+    <refmiscinfo class='manual'>Rivendell C Library Manual</refmiscinfo>
+  </refmeta>
+  <refnamediv>
+    <refname>rd_savelog</refname>
+    <refpurpose>Rivendell Save Log C Library Function</refpurpose>
+  </refnamediv>
+  <info>
+    <author>
+      <personname>
+        <firstname>Todd</firstname>
+        <surname>Baker</surname>
+        <email>bakert@rfa.org</email>
+      </personname>
+      <contrib>Rivendell C Library Author</contrib>
+    </author>
+  </info>
+
+  <!--
+                    Body
+  -->
+  <refsynopsisdiv id='synopsis'>
+    <funcsynopsis>
+    <funcsynopsisinfo>#include &lt;rivendell/rd_savelog.h&gt;</funcsynopsisinfo>
+    <funcprototype>
+    <funcdef>int <function>RD_SaveLog</function></funcdef>
+      <paramdef>struct save_loghdr_values <parameter>*hdrvals</parameter></paramdef>
+      <paramdef>struct save_logline_values <parameter>*linevals</parameter></paramdef>
+      <paramdef>unsigned <parameter>linevals_quan</parameter></paramdef>
+      <paramdef>const char <parameter>hostname[]</parameter></paramdef>
+      <paramdef>const char <parameter>username[]</parameter></paramdef>
+      <paramdef>const char <parameter>passwd[]</parameter></paramdef>
+      <paramdef>const char <parameter>log_name[]</parameter></paramdef>
+    </funcprototype> 
+    </funcsynopsis>
+
+  </refsynopsisdiv>
+
+  <refsect1 id='description'><title>Description</title>
+  <para>
+    <command>RD_SaveLog</command> is  the function to use
+    to save log information (both headers and lines) to an existing Rivendell
+    Database.
+  </para>
+  <para>
+    This function saves the specified log to the Rivendell database on
+    hostname.
+  </para>
+  <table xml:id="ex.savelog" frame="all">
+    <title>RD_SaveLog function call fields</title>
+    <tgroup cols="4" align="left" colsep="1" rowsep="1">
+      <colspec colname="FIELD NAME" />
+      <colspec colname="FIELD TYPE" />
+      <colspec colname="MEANING" />
+      <colspec colname="REMARKS" />
+      <thead>
+        <row>
+          <entry>
+            FIELD NAME
+          </entry>
+          <entry>
+            FIELD TYPE
+          </entry>
+          <entry>
+            MEANING
+          </entry>
+          <entry>
+            REMARKS
+          </entry>
+        </row>
+      </thead>
+      <tbody>
+        <row>
+          <entry>
+            hdrvals
+          </entry>
+          <entry>
+            Pointer to save_loghdr_values structure
+          </entry>
+          <entry>
+            Log header data
+          </entry>
+          <entry>
+            Mandatory
+          </entry>
+        </row>
+        <row>
+          <entry>
+            linevals
+          </entry>
+          <entry>
+            Pointer to save_logline_values structure
+          </entry>
+          <entry>
+            Log lines data
+          </entry>
+          <entry>
+            Mandatory
+          </entry>
+        </row>
+        <row>
+          <entry>
+            linevals_quan
+          </entry>
+          <entry>
+            Unsigned Integer
+          </entry>
+          <entry>
+            Number of lines in the linevals argument 
+          </entry>
+          <entry>
+            Mandatory
+          </entry>
+        </row>
+        <row>
+          <entry>
+            hostname
+          </entry>
+          <entry>
+          Character Array
+          </entry>
+          <entry>
+            Name Of Rivendell DB Host
+          </entry>
+          <entry>
+            Mandatory
+          </entry>
+        </row>
+        <row>
+          <entry>
+            username
+          </entry>
+          <entry>
+          Character Array
+          </entry>
+          <entry>
+            Rivendell User Name
+          </entry>
+          <entry>
+            Mandatory
+          </entry>
+        </row>
+        <row>
+          <entry>
+            passwd
+          </entry>
+          <entry>
+          Character Array
+          </entry>
+          <entry>
+            Rivendell User Password
+          </entry>
+          <entry>
+            Mandatory
+          </entry>
+        </row>
+        <row>
+          <entry>
+            log_name
+          </entry>
+          <entry>
+          Character Array
+          </entry>
+          <entry>
+            Name to assign to new log
+          </entry>
+          <entry>
+            Mandatory
+          </entry>
+        </row>
+      </tbody>
+    </tgroup>
+  </table>
+  <para>
+    Header data for the log is sent in a 'save_loghdr_values' struct, as
+    follows:
+  </para>
+  <programlisting>
+    struct save_loghdr_values {
+      char loghdr_service[11];
+      char loghdr_description[65];
+      int loghdr_autorefresh;
+      struct tm loghdr_purge_date;
+      struct tm loghdr_start_date;
+      struct tm loghdr_end_date;
+    };
+  </programlisting>
+  <para>
+    Each line in the log is sent in a 'save_logline_values' struct, as
+    follows:
+  </para>
+  <programlisting>
+    struct save_logline_values {
+      int  logline_id;
+      int  logline_type;
+      int  logline_source;
+      unsigned logline_cart_number;
+      int  logline_starttime;
+      int  logline_gracetime;
+      int  logline_time_type;
+      int  logline_transition_type;
+      int  logline_start_point_log;
+      int  logline_end_point_log;
+      int  logline_segue_start_point_log;
+      int  logline_segue_end_point_log;
+      int  logline_fadeup_point_log;
+      int  logline_fadedown_point_log;
+      int  logline_duckup_gain;
+      int  logline_duckdown_gain;
+      char logline_marker_comment[256];
+      char logline_marker_label[65];
+      char logline_origin_user[256];
+      struct tm logline_origin_datetime;
+      int  logline_event_length;
+      char logline_link_event_name[65];
+      struct tm logline_link_starttime;
+      int  logline_link_length;
+      int  logline_link_start_slop;
+      int  logline_link_end_slop;
+      int  logline_link_id;
+      int  logline_link_embedded;
+      struct tm logline_ext_starttime;
+      int  logline_ext_length;
+      char logline_ext_cart_name[33];
+      char logline_ext_data[33];
+      char logline_ext_event_id[33];
+      char logline_ext_annc_type[9];
+      };
+  </programlisting>
+  </refsect1>
+  <refsect2 id='returns'><title>RETURN VALUE</title>
+    <para>
+      On success, zero is returned.
+    </para>
+    <para>
+      If a server error occurs a -1 is returned.
+      If a client error occurs a specific error number is returned.
+    </para>
+  </refsect2>
+  <refsect3 id='errors'><title>ERRORS</title>
+    <para>
+      400          Invalid/Missing Parameter.
+    </para>
+    <para>
+      404          User Does Not Have Permission to Edit Logs or specified service does not exist.
+    </para>
+    <para>
+      500          Server error.
+    </para>
+    <para>
+      nnn  Unknown Error Occurred.
+    </para>
+  </refsect3>
+     
+</refentry>

--- a/rivendell/rd_savelog.c
+++ b/rivendell/rd_savelog.c
@@ -202,8 +202,8 @@ int RD_SaveLog(struct save_loghdr_values *hdrvals,
 	     linevals[i].logline_link_length);
     post=AppendString(post,str);
 
-    snprintf(str,1024,"&LINE%u_LINK_START_TIME=%u",i,
-	     linevals[i].logline_link_starttime);
+    RD_Cnv_tm_to_DTString(&linevals[i].logline_link_starttime,dtstr);
+    snprintf(str,1024,"&LINE%u_LINK_START_TIME=%s",i,dtstr);
     post=AppendString(post,str);
 
     snprintf(str,1024,"&LINE%u_LINK_START_SLOP=%u",i,
@@ -222,8 +222,8 @@ int RD_SaveLog(struct save_loghdr_values *hdrvals,
 	     linevals[i].logline_link_embedded);
     post=AppendString(post,str);
 
-    snprintf(str,1024,"&LINE%u_EXT_START_TIME=%u",i,
-	     linevals[i].logline_ext_starttime);
+    RD_Cnv_tm_to_DTString(&linevals[i].logline_ext_starttime,dtstr);
+    snprintf(str,1024,"&LINE%u_EXT_START_TIME=%s",i,dtstr);
     post=AppendString(post,str);
 
     snprintf(str,1024,"&LINE%u_EXT_LENGTH=%u",i,

--- a/rivendell/rd_savelog.c
+++ b/rivendell/rd_savelog.c
@@ -109,6 +109,9 @@ int RD_SaveLog(struct save_loghdr_values *hdrvals,
     snprintf(str,1024,"&LINE%u_START_TIME=%u",i,linevals[i].logline_starttime);
     post=AppendString(post,str);
 
+    snprintf(str,1024,"&LINE%u_GRACE_TIME=%u",i,linevals[i].logline_gracetime);
+    post=AppendString(post,str);
+
     snprintf(str,1024,"&LINE%u_ID=%u",i,linevals[i].logline_gracetime);
     post=AppendString(post,str);
 
@@ -133,6 +136,7 @@ int RD_SaveLog(struct save_loghdr_values *hdrvals,
       snprintf(str,1024,"&LINE%u_TRANS_TYPE=STOP",i);
       break;
     }
+    post=AppendString(post,str);
 
     snprintf(str,1024,"&LINE%u_START_POINT=%u",i,
 	     linevals[i].logline_start_point_log);
@@ -194,15 +198,19 @@ int RD_SaveLog(struct save_loghdr_values *hdrvals,
 	     curl_easy_escape(curl,linevals->logline_link_event_name,0));
     post=AppendString(post,str);
 
+    snprintf(str,1024,"&LINE%u_LINK_LENGTH=%u",i,
+	     linevals[i].logline_link_length);
+    post=AppendString(post,str);
+
     snprintf(str,1024,"&LINE%u_LINK_START_TIME=%u",i,
 	     linevals[i].logline_link_starttime);
     post=AppendString(post,str);
 
-    snprintf(str,1024,"&LINE%u_LINK_START_SLOT=%u",i,
+    snprintf(str,1024,"&LINE%u_LINK_START_SLOP=%u",i,
 	     linevals[i].logline_link_start_slop);
     post=AppendString(post,str);
 
-    snprintf(str,1024,"&LINE%u_LINK_END_SLOT=%u",i,
+    snprintf(str,1024,"&LINE%u_LINK_END_SLOP=%u",i,
 	     linevals[i].logline_link_end_slop);
     post=AppendString(post,str);
 

--- a/rivendell/rd_savelog.h
+++ b/rivendell/rd_savelog.h
@@ -56,16 +56,15 @@ struct save_logline_values {
   char logline_marker_label[65];
   char logline_origin_user[256];
   struct tm logline_origin_datetime;
-
   int  logline_event_length;
   char logline_link_event_name[65];
-  char logline_link_starttime[13];
+  struct tm logline_link_starttime;
   int  logline_link_length;
   int  logline_link_start_slop;
   int  logline_link_end_slop;
   int  logline_link_id;
   int  logline_link_embedded;
-  char logline_ext_starttime[13];
+  struct tm logline_ext_starttime;
   int  logline_ext_length;
   char logline_ext_cart_name[33];
   char logline_ext_data[33];

--- a/rivendell/rd_savelog.h
+++ b/rivendell/rd_savelog.h
@@ -60,6 +60,7 @@ struct save_logline_values {
   int  logline_event_length;
   char logline_link_event_name[65];
   char logline_link_starttime[13];
+  int  logline_link_length;
   int  logline_link_start_slop;
   int  logline_link_end_slop;
   int  logline_link_id;


### PR DESCRIPTION
This cleans up a number of small issues in the RD_SaveLog() call, plus adds a man page.

2017-02-08 Fred Gleason <fredg@paravelsystems.com>
	* Added the 'logline_gracetime' field to the
	'save_logline_values' struct in 'rivendell/rd_savelog.h'.
	* Added the 'logline_link_length' field to the
	'save_logline_values' struct in 'rivendell/rd_savelog.h'.
	* Fixed typos in 'rivendell/rd_savelog.c' that broke the
	RD_SaveLog() call.
	* Altered the 'logline_link_starttime' and 'logline_ext_starttime'
	fields of 'struct save_logline_values' to be 'struct tm' instead
	of 'char []'.
	* Added an rd_savelog(7) man page.
