### PR TITLE
Reformating the logline_forced_length

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -193,3 +193,5 @@
 	fields of 'struct save_logline_values' to be 'struct tm' instead
 	of 'char []'.
 	* Added an rd_savelog(7) man page.
+2017-02-08 Fred Gleason <fredg@paravelsystems.com>
+	* Added an 'logline_conductor' field to the 'rd_logline' struct.

--- a/ChangeLog
+++ b/ChangeLog
@@ -195,3 +195,6 @@
 	* Added an rd_savelog(7) man page.
 2017-02-10 Fred Gleason <fredg@paravelsystems.com>
 	* Added an 'logline_conductor' field to the 'rd_logline' struct.
+2017-02-15 Fred Gleason <fredg@paravelsystems.com>
+	* Changed the type of the 'logline_forced_length' field of the
+	'rd_logline' struct to return milliseconds.

--- a/ChangeLog
+++ b/ChangeLog
@@ -193,5 +193,5 @@
 	fields of 'struct save_logline_values' to be 'struct tm' instead
 	of 'char []'.
 	* Added an rd_savelog(7) man page.
-2017-02-08 Fred Gleason <fredg@paravelsystems.com>
+2017-02-10 Fred Gleason <fredg@paravelsystems.com>
 	* Added an 'logline_conductor' field to the 'rd_logline' struct.

--- a/docbook/rd_listlog.xml
+++ b/docbook/rd_listlog.xml
@@ -186,6 +186,7 @@ struct rd_logline {
   char logline_agency[65];
   char logline_publisher[65];
   char logline_composer[65];
+  char logline_conductor[65];
   char logline_user_defined[256];
   int  logline_usage_code;
   int  logline_enforce_length;
@@ -261,6 +262,8 @@ logline_agency			is a character arrray.
 logline_publisher		is a character arrray.
 
 logline_composer		is a character arrray.
+
+logline_conductor		is a character arrray.
 
 logline_user_defined	is a character arrray.
 

--- a/rivendell/rd_listlog.c
+++ b/rivendell/rd_listlog.c
@@ -176,7 +176,7 @@ static void XMLCALL __ListLogElementEnd(void *data, const char *el)
     logline->logline_enforce_length=RD_ReadBool(xml_data->strbuf);
   }
   if(strcasecmp(el,"forcedLength")==0) {
-    strlcpy(logline->logline_forced_length,xml_data->strbuf,9);
+    logline->logline_forced_length=RD_Cnv_TString_to_msec(xml_data->strbuf);
   }
   if(strcasecmp(el,"evergreen")==0) {
     logline->logline_evergreen=RD_ReadBool(xml_data->strbuf);

--- a/rivendell/rd_listlog.c
+++ b/rivendell/rd_listlog.c
@@ -163,6 +163,9 @@ static void XMLCALL __ListLogElementEnd(void *data, const char *el)
   if(strcasecmp(el,"agency")==0) {
     strlcpy(logline->logline_agency,xml_data->strbuf,65);
   }
+  if(strcasecmp(el,"conductor")==0) {
+    strlcpy(logline->logline_conductor,xml_data->strbuf,65);
+  }
   if(strcasecmp(el,"userDefined")==0) {
     strlcpy(logline->logline_user_defined,xml_data->strbuf,256);
   }

--- a/rivendell/rd_listlog.h
+++ b/rivendell/rd_listlog.h
@@ -42,6 +42,7 @@ struct rd_logline {
   char logline_agency[65];
   char logline_publisher[65];
   char logline_composer[65];
+  char logline_conductor[65];
   char logline_user_defined[256];
   int  logline_usage_code;
   int  logline_enforce_length;

--- a/rivendell/rd_listlog.h
+++ b/rivendell/rd_listlog.h
@@ -46,7 +46,8 @@ struct rd_logline {
   char logline_user_defined[256];
   int  logline_usage_code;
   int  logline_enforce_length;
-  char logline_forced_length[10];
+  //  char logline_forced_length[10];
+  int  logline_forced_length;
   int  logline_evergreen;
   int  logline_source;
   int  logline_time_type;

--- a/tests/listlog_test.c
+++ b/tests/listlog_test.c
@@ -111,10 +111,11 @@ int main(int argc,char *argv[])
     printf("                 LogLine Agency: %s\n",logline[i].logline_agency);
     printf("              LogLine Publisher: %s\n",logline[i].logline_publisher);
     printf("               LogLine Composer: %s\n",logline[i].logline_composer);
+    printf("              LogLine Conductor: %s\n",logline[i].logline_conductor);
     printf("           LogLine User Defined: %s\n",logline[i].logline_user_defined);
     printf("             LogLine Usage Code: %d\n",logline[i].logline_usage_code);
     printf("         LogLine Enforce Length: %d\n",logline[i].logline_enforce_length);
-    printf("          LogLine Forced Length: %s\n",logline[i].logline_forced_length);
+    printf("          LogLine Forced Length: %d\n",logline[i].logline_forced_length);
     printf("              LogLine Evergreen: %d\n",logline[i].logline_evergreen);
     printf("                 LogLine Source: %d\n",logline[i].logline_source);
     printf("              LogLine Time Type: %d\n",logline[i].logline_time_type);


### PR DESCRIPTION
2017-02-15 Fred Gleason <fredg@paravelsystems.com>
	* Changed the type of the 'logline_forced_length' field of the
	'rd_logline' struct to return milliseconds.