### PR TITLE
2017-02-16 Fred Gleason <fredg@paravelsystems.com>

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -202,3 +202,8 @@
 	* Added a 'cart_conductor' field to the 'rd_cart' struct.
 	* Added 'cart_composer' and 'use_cart_composer' fields to the
 	'rd_cart_values' struct.
+2017-02-16 Fred Gleason <fredg@paravelsystems.com>
+	* Fixed bugs in 'rivendell/rd_listcarts.c' and
+	'rivendell/rd_listcart.c' that caused the 'cart_forced_length',
+	'cart_average_length', 'cart_length_deviation' and
+	'cart_average_segue_length' fields to always be returned as '0'.

--- a/rivendell/rd_listcart.c
+++ b/rivendell/rd_listcart.c
@@ -121,19 +121,19 @@ static void XMLCALL __ListCartElementEnd(void *data, const char *el)
     sscanf(xml_data->strbuf,"%d",&carts->cart_usage_code);
   }
   if(strcasecmp(el,"forcedLength")==0) {
-    sscanf(xml_data->strbuf,"%d",&carts->cart_forced_length);
+    carts->cart_forced_length=RD_Cnv_TString_to_msec(xml_data->strbuf);
   }
   if(strcasecmp(el,"averageLength")==0) {
-    sscanf(xml_data->strbuf,"%d",&carts->cart_average_length);
+    carts->cart_average_length=RD_Cnv_TString_to_msec(xml_data->strbuf);
   }
   if(strcasecmp(el,"lengthDeviation")==0) {
-    sscanf(xml_data->strbuf,"%d",&carts->cart_length_deviation);
+    carts->cart_length_deviation=RD_Cnv_TString_to_msec(xml_data->strbuf);
   }
   if(strcasecmp(el,"averageSegueLength")==0) {
-    sscanf(xml_data->strbuf,"%d",&carts->cart_average_segue_length);
+    carts->cart_average_segue_length=RD_Cnv_TString_to_msec(xml_data->strbuf);
   }
   if(strcasecmp(el,"averageHookLength")==0) {
-    sscanf(xml_data->strbuf,"%d",&carts->cart_average_hook_length);
+    carts->cart_average_hook_length=RD_Cnv_TString_to_msec(xml_data->strbuf);
   }
   if(strcasecmp(el,"cutQuantity")==0) {
     sscanf(xml_data->strbuf,"%u",&carts->cart_cut_quantity);

--- a/rivendell/rd_listcarts.c
+++ b/rivendell/rd_listcarts.c
@@ -121,19 +121,19 @@ static void XMLCALL __ListCartsElementEnd(void *data, const char *el)
     sscanf(xml_data->strbuf,"%d",&carts->cart_usage_code);
   }
   if(strcasecmp(el,"forcedLength")==0) {
-    sscanf(xml_data->strbuf,"%d",&carts->cart_forced_length);
+    carts->cart_forced_length=RD_Cnv_TString_to_msec(xml_data->strbuf);
   }
   if(strcasecmp(el,"averageLength")==0) {
-    sscanf(xml_data->strbuf,"%d",&carts->cart_average_length);
+    carts->cart_average_length=RD_Cnv_TString_to_msec(xml_data->strbuf);
   }
   if(strcasecmp(el,"lengthDeviation")==0) {
-    sscanf(xml_data->strbuf,"%d",&carts->cart_length_deviation);
+    carts->cart_length_deviation=RD_Cnv_TString_to_msec(xml_data->strbuf);
   }
   if(strcasecmp(el,"averageSegueLength")==0) {
-    sscanf(xml_data->strbuf,"%d",&carts->cart_average_segue_length);
+    carts->cart_average_segue_length=RD_Cnv_TString_to_msec(xml_data->strbuf);
   }
   if(strcasecmp(el,"averageHookLength")==0) {
-    sscanf(xml_data->strbuf,"%d",&carts->cart_average_hook_length);
+    carts->cart_average_hook_length=RD_Cnv_TString_to_msec(xml_data->strbuf);
   }
   if(strcasecmp(el,"cutQuantity")==0) {
     sscanf(xml_data->strbuf,"%u",&carts->cart_cut_quantity);


### PR DESCRIPTION
	* Fixed bugs in 'rivendell/rd_listcarts.c' and
	'rivendell/rd_listcart.c' that caused the 'cart_forced_length',
	'cart_average_length', 'cart_length_deviation' and
	'cart_average_segue_length' fields to always be returned as '0'.