### PR TITLE
2017-02-21 Fred Gleason <fredg@paravelsystems.com>

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -207,3 +207,6 @@
 	'rivendell/rd_listcart.c' that caused the 'cart_forced_length',
 	'cart_average_length', 'cart_length_deviation' and
 	'cart_average_segue_length' fields to always be returned as '0'.
+2017-02-21 Fred Gleason <fredg@paravelsystems.com>
+	* Fixed a buffer overflow bug in RD_Cnv_tm_to_DTString() in
+	'rivendell/rd_common.c'.

--- a/rivendell/rd_common.c
+++ b/rivendell/rd_common.c
@@ -147,7 +147,7 @@ size_t RD_Cnv_tm_to_DTString(struct tm *tmptr,char * dest)
     char thesec[3];
     char plusminus[3];
     char minus[2] = "-";
-    char colon_sep[3] = "%3a";
+    char colon_sep[4] = "%3a";
     char T_sep[2] = "T";
     char offsethr[3];
     char offsetmin[3];


### PR DESCRIPTION
	* Fixed a buffer overflow bug in RD_Cnv_tm_to_DTString() in
	'rivendell/rd_common.c'.