### PR TITLE
2017-02-23 Fred Gleason <fredg@paravelsystems.com>

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -216,3 +216,6 @@
 2017-02-23 Fred Gleason <fredg@paravelsystems.com>
 	* Fixed a bug in 'rivendell/rd_savelog.c' that caused the value of
 	certain logline fields to be used for every line.
+2017-02-23 Fred Gleason <fredg@paravelsystems.com>
+	* Added a conditional compile in 'rivendell/rd_common.c' to avoid
+	the use of localtime_r() on MingW32.

--- a/rivendell/rd_common.c
+++ b/rivendell/rd_common.c
@@ -110,7 +110,11 @@ struct tm RD_Cnv_DTString_to_tm( const char *datein)
 //    Get the local offset from UTC
     offsetfromutc = get_local_offset();
     newrawtime += offsetfromutc;
+#ifdef _WIN32
+    localtime(&newrawtime);
+#else
     localtime_r(&newrawtime,tmptr);
+#endif  // _WIN32
     return datetimetm;
 }
     


### PR DESCRIPTION
localtime_r() does not exist in MingW32. This pull request changes 'rivendell/rd_common.c' to use localtime() rather than localtime_r() on
Win32 platforms.  Unlike on POSIX platforms, localtime() is thread-safe on Win32/64.  For some background discussion, see http://mingw.5.n7.nabble.com/Need-localtime-s-td11057.html.

ChangeLog:
	* Added a conditional compile in 'rivendell/rd_common.c' to avoid
	the use of localtime_r() on MingW32.