### PR TITLE
Savelog fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -247,3 +247,6 @@
 	'save_logline_values' struct in 'rivendell/rd_savelog.h'.
 	* Added 'logline_fadedown_gain' to the 'rd_logline' struct in
 	'rivendell/rd_listlog.h'.
+2017-06-26 Fred Gleason <fredg@paravelsystems.com>
+	* Fixed a bug in 'rivendell_rd_savelog.c' that caused the
+	'TIME_TYPE' value to fail to be saved.

--- a/ChangeLog
+++ b/ChangeLog
@@ -238,3 +238,12 @@
 	procedures.
 	*  Updated tests and docbook entries to show correct error code 
 	return values.
+2017-06-26 Fred Gleason <fredg@paravelsystems.com>
+	* Fixed bugs in 'rivendell/rd_savelog.c' that caused negative values
+	for 'START_POINT', 'END_POINT', 'SEGUE_START_POINT',
+	'SEGUE_END_POINT', 'FADEUP_POINT', 'FADEDOWN_POINT',
+	'DUCK_UP_GAIN' and 'DUCK_DOWN_GAIN' to be corrupted.
+	* Added 'logline_fadeup_gain' and 'logline_fadedown_gain' to the
+	'save_logline_values' struct in 'rivendell/rd_savelog.h'.
+	* Added 'logline_fadedown_gain' to the 'rd_logline' struct in
+	'rivendell/rd_listlog.h'.

--- a/rivendell/rd_listlog.c
+++ b/rivendell/rd_listlog.c
@@ -327,6 +327,9 @@ static void XMLCALL __ListLogElementEnd(void *data, const char *el)
       }
     }
   }
+  if(strcasecmp(el,"fadedownGain")==0) {
+      sscanf(xml_data->strbuf,"%d",&logline->logline_fadedown_gain);
+  }
   if(strcasecmp(el,"duckUpGain")==0) {
       sscanf(xml_data->strbuf,"%d",&logline->logline_duckup_gain);
   }

--- a/rivendell/rd_listlog.h
+++ b/rivendell/rd_listlog.h
@@ -73,6 +73,7 @@ struct rd_logline {
   int  logline_fadeup_gain;
   int  logline_fadedown_point_cart;
   int  logline_fadedown_point_log;
+  int  logline_fadedown_gain;
   int  logline_duckup_gain;
   int  logline_duckdown_gain;
   int  logline_talk_start_point;

--- a/rivendell/rd_savelog.c
+++ b/rivendell/rd_savelog.c
@@ -139,35 +139,43 @@ int RD_SaveLog(struct save_loghdr_values *hdrvals,
     }
     post=AppendString(post,str);
 
-    snprintf(str,1024,"&LINE%u_START_POINT=%u",i,
+    snprintf(str,1024,"&LINE%u_START_POINT=%d",i,
 	     linevals[i].logline_start_point_log);
     post=AppendString(post,str);
 
-    snprintf(str,1024,"&LINE%u_END_POINT=%u",i,
+    snprintf(str,1024,"&LINE%u_END_POINT=%d",i,
 	     linevals[i].logline_end_point_log);
     post=AppendString(post,str);
 
-    snprintf(str,1024,"&LINE%u_SEGUE_START_POINT=%u",i,
+    snprintf(str,1024,"&LINE%u_SEGUE_START_POINT=%d",i,
 	     linevals[i].logline_segue_start_point_log);
     post=AppendString(post,str);
 
-    snprintf(str,1024,"&LINE%u_SEGUE_END_POINT=%u",i,
+    snprintf(str,1024,"&LINE%u_SEGUE_END_POINT=%d",i,
 	     linevals[i].logline_segue_end_point_log);
     post=AppendString(post,str);
 
-    snprintf(str,1024,"&LINE%u_FADEUP_POINT=%u",i,
+    snprintf(str,1024,"&LINE%u_FADEUP_POINT=%d",i,
 	     linevals[i].logline_fadeup_point_log);
     post=AppendString(post,str);
 
-    snprintf(str,1024,"&LINE%u_FADEDOWN_POINT=%u",i,
+    snprintf(str,1024,"&LINE%u_FADEUP_GAIN=%d",i,
+	     linevals[i].logline_fadeup_gain);
+    post=AppendString(post,str);
+
+    snprintf(str,1024,"&LINE%u_FADEDOWN_POINT=%d",i,
 	     linevals[i].logline_fadedown_point_log);
     post=AppendString(post,str);
 
-    snprintf(str,1024,"&LINE%u_DUCK_UP_GAIN=%u",i,
+    snprintf(str,1024,"&LINE%u_FADEDOWN_GAIN=%d",i,
+	     linevals[i].logline_fadedown_gain);
+    post=AppendString(post,str);
+
+    snprintf(str,1024,"&LINE%u_DUCK_UP_GAIN=%d",i,
 	     linevals[i].logline_duckup_gain);
     post=AppendString(post,str);
 
-    snprintf(str,1024,"&LINE%u_DUCK_DOWN_GAIN=%u",i,
+    snprintf(str,1024,"&LINE%u_DUCK_DOWN_GAIN=%d",i,
 	     linevals[i].logline_duckdown_gain);
     post=AppendString(post,str);
 

--- a/rivendell/rd_savelog.c
+++ b/rivendell/rd_savelog.c
@@ -116,12 +116,7 @@ int RD_SaveLog(struct save_loghdr_values *hdrvals,
     snprintf(str,1024,"&LINE%u_GRACE_TIME=%u",i,linevals[i].logline_gracetime);
     post=AppendString(post,str);
 
-    if(linevals[i].logline_time_type==1) {
-      snprintf(str,1024,"&LINE%u_TIME_TYPE=Hard",i);
-    }
-    else {
-      snprintf(str,1024,"&LINE%u_TIME_TYPE=Relative",i);
-    }
+    snprintf(str,1024,"&LINE%u_TIME_TYPE=%u",i,linevals[i].logline_time_type);
     post=AppendString(post,str);
 
     switch(linevals[i].logline_transition_type) {

--- a/rivendell/rd_savelog.h
+++ b/rivendell/rd_savelog.h
@@ -49,7 +49,9 @@ struct save_logline_values {
   int  logline_segue_start_point_log;
   int  logline_segue_end_point_log;
   int  logline_fadeup_point_log;
+  int  logline_fadeup_gain;
   int  logline_fadedown_point_log;
+  int  logline_fadedown_gain;
   int  logline_duckup_gain;
   int  logline_duckdown_gain;
   char logline_marker_comment[256];


### PR DESCRIPTION
2017-06-26 Fred Gleason <fredg@paravelsystems.com>
	* Fixed bugs in 'rivendell/rd_savelog.c' that caused negative values
	for 'START_POINT', 'END_POINT', 'SEGUE_START_POINT',
	'SEGUE_END_POINT', 'FADEUP_POINT', 'FADEDOWN_POINT',
	'DUCK_UP_GAIN' and 'DUCK_DOWN_GAIN' to be corrupted.
	* Added 'logline_fadeup_gain' and 'logline_fadedown_gain' to the
	'save_logline_values' struct in 'rivendell/rd_savelog.h'.
	* Added 'logline_fadedown_gain' to the 'rd_logline' struct in
	'rivendell/rd_listlog.h'.
2017-06-26 Fred Gleason <fredg@paravelsystems.com>
	* Fixed a bug in 'rivendell_rd_savelog.c' that caused the
	'TIME_TYPE' value to fail to be saved.
